### PR TITLE
reviewing types for TS and Golang

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # Example for assigning to the Solutions Factory 
 # @solutions-factory
 
-# @REPLACE_WITH_YOUR_TEAM_OR_USER
+* @solutions-architects @solutions-factory

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 
 # Example for assigning to the Solutions Factory 
 # @solutions-factory
-
-* @solutions-architects @solutions-factory
+@solutions-factory
+@solutions-architects

--- a/go/types.go
+++ b/go/types.go
@@ -1,20 +1,20 @@
 package main
 
 type CoprocessorRequest struct {
-	Version     int                 `json:"version"`
-	Stage       Stage               `json:"stage"`
-	Control     Control             `json:"control"`
-	ID          string              `json:"id"`
-	Headers     map[string][]string `json:"headers,omitempty"`
-	Body        interface{}         `json:"body,omitempty"`
-	Context     Context             `json:"context,omitempty"`
-	SDL         string              `json:"sdl,omitempty"`
-	Path        string              `json:"path,omitempty"`
-	Method      string              `json:"method,omitempty"`
-	ServiceName string              `json:"serviceName,omitempty"`
-	StatusCode  int                 `json:"statusCode,omitempty"`
-	URI         string              `json:"uri,omitempty"`
-	HasNext     bool                `json:"hasNext,omitempty"`
+	Version     int                  `json:"version"`
+	Stage       Stage                `json:"stage"`
+	Control     Control              `json:"control"`
+	ID          string               `json:"id"`
+	Headers     *map[string][]string `json:"headers,omitempty"`
+	Body        *interface{}         `json:"body,omitempty"` // Body can be either an object containing the body of the request, or a string depending on the stage.
+	Context     *Context             `json:"context,omitempty"`
+	SDL         string               `json:"sdl,omitempty"`
+	Path        string               `json:"path,omitempty"`
+	Method      string               `json:"method,omitempty"`
+	ServiceName string               `json:"serviceName,omitempty"`
+	URI         string               `json:"uri,omitempty"`
+	StatusCode  *int                 `json:"statusCode,omitempty"`
+	HasNext     *bool                `json:"hasNext,omitempty"`
 }
 
 type CoprocessorResponse struct {

--- a/typescript/types.ts
+++ b/typescript/types.ts
@@ -1,74 +1,89 @@
-interface CoprocessorRequest {
-  version: number;
-  stage: RouterStage;
-  control: 'continue';
-  id: string;
-  headers?: Record<string, string[]>;
-  body?: string | object;
-  context?: RouterContext;
-  sdl?: string;
-  path?: string;
-  method?: string;
-  serviceName?: string;
-  statusCode?: number;
-  uri?: string;
-  hasNext?: boolean;
+// Type definitions pulled from the following link: https://www.apollographql.com/docs/router/customizations/coprocessor#property-reference
+interface Coprocessor {
+    id: string;
+    version: number;
+    stage: RouterStage;
+    headers?: Record<string, string[]>;
+    body?: string | object;
+    context?: RouterContext;
+    sdl?: string;
+    path?: string;
+    method?: string;
+    serviceName?: string;
+    statusCode?: number;
+    uri?: string;
+    hasNext?: boolean;
+    query_plan?: object; // https://www.apollographql.com/docs/router/customizations/coprocessor#query_plan
 }
 
-interface CoprocessorResponse extends CoprocessorRequest {
-  control: CoprocessorControl;
+interface CoprocessorRequest extends Coprocessor {
+    control: 'continue';
+}
+
+interface CoprocessorControlBreak {
+    break: number;
+}
+
+type CoprocessorControl = 'continue' | CoprocessorControlBreak;
+
+interface CoprocessorResponse extends Coprocessor {
+    control: CoprocessorControl;
 }
 
 enum RouterStage {
-  RouterRequest = 'RouterRequest',
-  RouterResponse = 'RouterResponse',
-  SupergraphRequest = 'SupergraphRequest',
-  SupergraphResponse = 'SupergraphResponse',
-  SubgraphRequest = 'SubgraphRequest',
-  SubgraphResponse = 'SubgraphResponse'
+    RouterRequest = 'RouterRequest',
+    RouterResponse = 'RouterResponse',
+    SupergraphRequest = 'SupergraphRequest',
+    SupergraphResponse = 'SupergraphResponse',
+    ExecutionRequest = 'ExecutionRequest',
+    ExecutionResponse = 'ExecutionResponse',
+    SubgraphRequest = 'SubgraphRequest',
+    SubgraphResponse = 'SubgraphResponse'
 }
 
 type RouterControl = 'continue' | RouterControlBreak;
 
 interface RouterControlBreak {
-  break: number;
+    break: number;
 }
 
 interface RouterContext {
-  entries: Record<string, any>;
+    entries: Record<string, any>;
 }
 
 // Example usage:
 const exampleRequest: CoprocessorRequest = {
-  version: 1,
-  stage: 'RouterRequest',
-  control: 'continue',
-  id: '1b19c05fdafc521016df33148ad63c1b',
-  headers: {
-    "content-type": ["application/json"]
-  },
-  body: {
-    query: "query GetActiveUser { me { name } }"
-  },
-  context: {
-    entries: {
-      "accepts-json": true
-    }
-  },
-  path: "/",
-  method: "POST"
+    version: 1,
+    stage: RouterStage.RouterRequest,
+    control: 'continue',
+    id: '1b19c05fdafc521016df33148ad63c1b',
+    headers: {
+        "content-type": ["application/json"]
+    },
+    body: {
+        query: "query GetActiveUser { me { name } }"
+    },
+    context: {
+        entries: {
+            "accepts-json": true
+        }
+    },
+    path: "/",
+    method: "POST"
 };
 
+// exampleRequest will be used here to fill out the necessary values to send back to the router
 const exampleResponse: CoprocessorResponse = {
-  control: { break: 401 },
-  body: {
-    errors: [
-      {
-        message: "Not authenticated.",
-        extensions: {
-          code: "ERR_UNAUTHENTICATED"
-        }
-      }
-    ]
-  }
+    ...exampleRequest,
+    control: { break: 401 },
+    body: {
+        errors: [
+            {
+                message: "Not authenticated.",
+                extensions: {
+                    code: "ERR_UNAUTHENTICATED"
+                }
+            }
+        ]
+    }
 };


### PR DESCRIPTION
Reviewing the types for easier use. 

For Typescript: 

* Added the `ExecutionService` related stages as well as the query_plan object
* Modified the `CoprocessorRequst`/`Response` to use the default interface, but also concretely set the correct typing for the `control` attribute on `Request`s. 
* Updated example since it was generating an error in TS

For Golang: 

* JSON tags in Golang act oddly depending on how they're parsed. For example, the `StatusCode` would be coerced as `0` when being unmarshalled from an incoming request, even if that's invalid. By setting this (and `HasNext`) to a pointer, we avoid it unmarshalling/marshalling incorrectly
